### PR TITLE
fix: use correct operator for exponentiation

### DIFF
--- a/lib/Physics/Unit.pm
+++ b/lib/Physics/Unit.pm
@@ -101,12 +101,12 @@ InitPrefix (
     'yocto',   1e-24,
 
     # binary prefixes
-    'kibi',    2^10,
-    'mebi',    2^20,
-    'gibi',    2^30,
-    'tebi',    2^40,
-    'pebi',    2^50,
-    'exbi',    2^60,
+    'kibi',    2**10,
+    'mebi',    2**20,
+    'gibi',    2**30,
+    'tebi',    2**40,
+    'pebi',    2**50,
+    'exbi',    2**60,
 
     # others
     'semi',    0.5,


### PR DESCRIPTION
This pull requests fixes the computation of prefixes like kibi, mebi, kibi, ...
Perl uses the ** operator for exponentiation, the operator ^ is used for bitwise xor.