### PR TITLE
Updates to examples, tests, POD, overloading in Scalar.pm, more units…

### DIFF
--- a/eg/OverloadExample.pl
+++ b/eg/OverloadExample.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+use strict;
+# overloaded interface example
+
+# simple projectile motion simulation on different planets
+use Physics::Unit::Scalar ':ALL';
+@Physics::Unit::Scalar::type_context = ('Energy');      # we are working with energy i.e. Joules
+$Physics::Unit::Scalar::format_string = "%.3f";         # provide a format string for output
+my $m = GetScalar("1 Kg");                              # mass
+my $u = GetScalar("1 meter per second");                # initial upward velocity
+foreach my $body ( qw(mercury earth mars jupiter pluto) ) {
+    my $a = GetScalar("-1 $body-gravity");              # e.g. "-1 earth-gravity" (-1 for direction vector)
+    my $t = GetScalar("0 seconds");                     # start at t = 0s
+    print "On " . ucfirst($body) . ":\n";               # so we know which planet we're on
+    while ( $t < 3.5 ) {                                # simulate for a few seconds
+        my $s = $u * $t + (1/2) * $a * $t**2;           # 'suvat' equations
+        my $v = $u + $a * $t;
+        my $KE = (1/2) * $m * $v**2;                    # kinetic energy
+        my $PE = $m * -1 * $a * $s;                     # potential energy, again -1 for direction
+        my $TE = $KE + $PE;                             # total energy (should be constant)
+        # display with units
+        print "At $t: dist = $s;\tvel = $v;\tKE = $KE;\tPE = $PE;\tTotal energy = $TE\n";
+        $t += 0.1;                                      # increment timestep
+    }
+}
+

--- a/eg/ScalarDocExamples.pl
+++ b/eg/ScalarDocExamples.pl
@@ -35,13 +35,13 @@ header("Physics::Unit::Scalar", "SYNOPSIS");
     print $t->ToString, "\n";              # prints 129600 second
 
     # Speed = Distance / Time
-    $s = $d->div($t);            # $s is a Physics::Unit::Speed object
+    $s = $d->divide($t);            # $s is a Physics::Unit::Speed object
     print $s->ToString, "\n";    # prints 1.2941... mps
 
     # Automatic typing
     $s = new Physics::Unit::Scalar('kg m s');   # Unrecognized type
     print ref $s, "\n";          # $s is a Physics::Unit::Scalar
-    $f = $s->div('3000 s^3');
+    $f = $s->divide('3000 s^3');
     print ref $f, "\n";          # $f is a Physics::Unit::Force
 
 
@@ -51,7 +51,7 @@ header("Physics::Unit::Scalar", "DESCRIPTION");
   $d = new Physics::Unit::Distance('98 mi');
   $t = new Physics::Unit::Time('36 years');
   # $s will be of type Physics::Unit::Speed.
-  $s = $d->div($t);
+  $s = $d->divide($t);
 
   print ref $s, "\n";
 

--- a/eg/ScalarSimple.pl
+++ b/eg/ScalarSimple.pl
@@ -28,7 +28,7 @@ print "36 years is " . $t->ToString . "\n";
 
 
 # Compute a Speed = Distance / Time
-$speed = $d->div($t);
+$speed = $d->divide($t);
 print "Speed is " . $speed->ToString . "\n";
 
 
@@ -39,6 +39,6 @@ $s = new Physics::Unit::Scalar('kg m s');
 # This calculation produces an object of the correct type
 # automagically:  $f is a Physics::Unit::Force
 
-$f = $s->div('3000 s^3');
+$f = $s->divide('3000 s^3');
 print "Force is " . $f->ToString . "\n";
 

--- a/lib/Physics/Unit.pm
+++ b/lib/Physics/Unit.pm
@@ -201,10 +201,22 @@ InitUnit (
 
     ['nautical-mile', 'nmi', 'nauticalmiles',
      'nauticalmile', 'nautical-miles',],        '1852 m',           # exact
-    ['astronomical-unit', 'au',],               '1.49598e11 m',
+    ['astronomical-unit', 'au', 'earth-to-sun'],   '149597870700 m',
     ['light-year', 'ly', 'light-years',
      'lightyear', 'lightyears'],                '9.46e15 m',
     ['parsec', 'parsecs',],                     '3.083e16 m',
+
+    # from https://nssdc.gsfc.nasa.gov/planetary/factsheet/planet_table_ratio.html
+    ['moon-to-sun'],                           '1 au',             # ???
+    ['mercury-to-sun'],                        '0.387 au',
+    ['venus-to-sun'],                          '0.723 au',
+    ['mars-to-sun'],                           '1.52 au',
+    ['jupiter-to-sun'],                        '5.2 au',
+    ['saturn-to-sun'],                         '9.57 au',
+    ['uranus-to-sun'],                         '19.17 au',
+    ['neptune-to-sun'],                        '30.18 au',
+    ['pluto-to-sun'],                          '39.48 au',
+
 
     # equatorial radius of the reference geoid:
     ['re'],                          '6378388 m',    # exact
@@ -213,6 +225,17 @@ InitUnit (
 
     # Acceleration
     ['g0', 'earth-gravity'],                    '9.80665 m/s^2',    # exact
+
+    # from https://nssdc.gsfc.nasa.gov/planetary/factsheet/planet_table_ratio.html
+    ['moon-gravity'],                           '0.166 earth-gravity',
+    ['mercury-gravity'],                        '0.378 earth-gravity',
+    ['venus-gravity'],                          '0.907 earth-gravity',
+    ['mars-gravity'],                           '0.377 earth-gravity',
+    ['jupiter-gravity'],                        '2.36 earth-gravity',
+    ['saturn-gravity'],                         '0.916 earth-gravity',
+    ['uranus-gravity'],                         '0.889 earth-gravity',
+    ['neptune-gravity'],                        '1.12 earth-gravity',
+    ['pluto-gravity'],                          '0.071 earth-gravity',
 
     # Mass
     ['kg',],                                    'kilogram',         # exact
@@ -255,7 +278,7 @@ InitUnit (
     # Time
     ['minute', 'min', 'mins', 'minutes'],               '60 s',
     ['hour', 'hr', 'hrs', 'hours'],                     '60 min',
-    ['day', 'days'],    '24 hr',
+    ['day', 'days', 'earth-day', 'earth-days'],         '24 hr',
     ['week', 'wk', 'weeks'],                            '7 days',
     ['fortnight', 'fortnights'],                        '2 week',
     ['year', 'yr', 'yrs', 'years'],                     '365.25 days',
@@ -268,6 +291,17 @@ InitUnit (
     ['us', 'usec', 'usecs'], 'microsecond',
     ['ns', 'nsec', 'nsecs'], 'nanosecond',
     ['ps', 'psec', 'psecs'], 'picosecond',
+
+    # from https://nssdc.gsfc.nasa.gov/planetary/factsheet/planet_table_ratio.html
+    ['moon-day', 'moon-days',],                         '29.5 earth-days',
+    ['mercury-day', 'mercury-days'],                    '175.9 earth-days',
+    ['venus-day', 'venus-days',],                       '116.8 earth-days',
+    ['mars-day', 'mars-days',],                         '1.03 earth-days',
+    ['jupiter-day', 'jupiter-days',],                   '0.414 earth-days',
+    ['saturn-day', 'saturn-days',],                     '0.444 earth-days',
+    ['uranus-day', 'uranus-days',],                     '0.718 earth-days',
+    ['neptune-day', 'neptune-days',],                   '0.671 earth-days',
+    ['pluto-day', 'pluto-days',],                       '6.39 earth-days',
 
     # Data
     ['byte', 'bytes'], '8 bits',
@@ -1808,8 +1842,6 @@ Here are some other modules that might fit your needs better than this one:
 
 =item * L<Physics::Udunits2>
 
-=item * L<mathjs>  supports units (JavaScript)
-
 =back
 
 =head1 AUTHOR
@@ -1819,3 +1851,11 @@ Written by Chris Maloney <voldrani@gmail.com>
 Special thanks for major contributions and encouragement from Joel Berger.
 Thanks also to Ben Bullock, and initial help in formatting for distribution
 from Gene Boggs <cpan@ology.net>.
+
+=head1 COPYRIGHT AND LICENSE
+
+Copyright 2002-2003 by Chris Maloney
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+

--- a/lib/Physics/Unit/Scalar.pm
+++ b/lib/Physics/Unit/Scalar.pm
@@ -293,6 +293,291 @@ sub ScalarResolve {
     bless $self, $type;
 }
 
+
+######### Overloading ######################
+# Doesn't use the existing methods but
+# defines new ones, so as not to interfere 
+# with any existing functionality.
+############################################
+
+our $format_string; # can be set to provide a 
+# parameter for sprintf() in the overloaded
+# ToString function.
+
+sub _overload_ToString {
+    my $self = shift;
+
+    return sprintf($format_string, $self->value) .' '. $self->MyUnit->ToString
+        if defined $format_string;
+
+    return $self->value .' '. $self->MyUnit->ToString;
+}
+
+sub _overload_eq {
+    my $self = shift;
+    my $other = GetScalar(shift);
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_eq'
+        if !ref $self || !ref $other;
+
+    return $self->_overload_ToString() eq $other->_overload_ToString();
+}
+
+# There appears to be a bug in ScalarResolve()
+# if $mu->type comes back with an arrayref,
+# e.g. in the case of ambiguous type for a derived 
+# unit such as ['Energy', 'Torque'], then it crashes,
+# as it doesn't seem to be able to handle that.
+# _ScalarResolve() tries to fix this by checking
+# global variable @type_context to see if the user 
+# has set a preferred type to use (a hacky solution,
+# admittedly); or if not, it just takes the first 
+# entry in the type arrayref so as not to crash.
+
+our @type_context = ();
+
+# See if the user has set a preferred unit type for
+# the calculations they are performing. 
+sub _DisambiguateType {
+    my $ar = shift;
+
+    if ( scalar(@type_context) ) {        
+        foreach my $type (@{$ar}) {
+            foreach my $preferred (@type_context) {
+                if ( $type eq $preferred ) {
+                    return $type;
+                }
+            }
+        }
+    }
+
+    return $ar->[0];
+}   
+
+sub _ScalarResolve {
+    my $self = shift;
+
+    my $mu = $self->{MyUnit};
+    my $type = $mu->type;
+
+    if ($type) {
+        $type = _DisambiguateType($type) if ref($type) eq 'ARRAY';
+        $type = 'dimensionless' if $type eq 'prefix';
+        $type = 'Physics::Unit::' . $type;
+
+        my $newunit = GetMyUnit($type);
+        $self->{value} *= $mu->convert($newunit);
+        $self->{MyUnit} = $newunit;
+        $self->{default_unit} = $newunit;
+    }
+    else {
+        $type = "Physics::Unit::Scalar";
+
+        $self->{value} *= $mu->factor;
+        $mu->factor(1);
+        $self->{default_unit} = $mu;
+    }
+
+    bless $self, $type;
+}
+
+sub _overload_add {
+    my $self = shift;
+    my $other = GetScalar(shift);
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_add'
+        if !ref $self || !ref $other;
+
+    # overloading should return a new object
+    my $n = $self->new();
+
+    # be a bit strict here about what can be added to what else
+    if (    (ref($self) eq ref($other)) || 
+            (ref($self) eq 'Physics::Unit::Dimensionless') || 
+            (ref($other) eq 'Physics::Unit::Dimensionless') ) {
+
+        $n->{value} += $other->{value};
+    }
+    else {
+        carp 'Cannot add a ' . ref($self) . ' to a ' . ref($other);
+    }
+
+    return $n;
+}
+
+sub _overload_subtract {
+    my $self = shift;
+    my $other = GetScalar(shift);
+    my $swapped = shift;
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_subtract'
+        if !ref $self || !ref $other;
+
+    my $n = $self->new();
+
+    if (    (ref($self) eq ref($other)) || 
+            (ref($self) eq 'Physics::Unit::Dimensionless') || 
+            (ref($other) eq 'Physics::Unit::Dimensionless') ) {
+
+        if ( defined($swapped) and ($swapped == 1) ) {
+            $n->{value} = $other->{value} - $n->{value};
+        }
+        else {
+            $n->{value} -= $other->{value};
+        }
+    }
+    else {
+
+        if ( defined($swapped) and ($swapped == 1) ) {
+            carp 'Cannot subtract a ' . ref($self) . ' from a ' . ref($other);
+        }
+        else {
+            carp 'Cannot subtract a ' . ref($other) . ' from a ' . ref($self);
+        }
+    }
+
+    return $n;
+}
+
+sub _overload_times {
+    my $self = shift;
+    my $other = GetScalar(shift);
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_times' 
+        if !ref $self || !ref $other;
+
+    my $value = $self->{value} * $other->{value};
+
+    my $mu = $self->{MyUnit}->copy;
+
+    $mu->times($other->{MyUnit});
+
+    my $newscalar = {
+        value  => $value,
+        MyUnit => $mu,
+    };
+
+    return _ScalarResolve($newscalar);
+}
+
+sub _overload_divide {
+    my $self = shift;
+    my $other = GetScalar(shift);
+    my $swapped = shift;
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_divide'
+        if !ref $self || !ref $other;
+
+    if ( defined($swapped) and ($swapped == 1) ) {
+        my $arg = $self->recip;
+        return $other->times($arg);
+    }
+    else {
+        my $arg = $other->recip;
+        return $self->times($arg);
+    }
+}
+
+sub _overload_power {
+    my $self = shift;
+    my $other = GetScalar(shift);
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_power'
+        if !ref $self || !ref $other;
+    
+    croak "Physics::Unit::Scalar::_overload_power: can only raise to dimensionless powers (got '$other')"
+        if ref($other) ne 'Physics::Unit::Dimensionless';
+
+    my $p = $other->value();
+
+    croak "Physics::Unit::Scalar::_overload_power: can only raise to integer powers currently (got '$p')"
+        unless $p == int($p);
+
+    my $n = $self->new();
+
+    # be explicit about different scenarios
+    if ( $p < -1 ) {
+        $p = abs($p)-1;
+        $n = $n->times($self) while $p--;
+        return $n->recip;
+    }
+    elsif ( $p == -1 ) {
+        return $n->recip;
+    }
+    elsif ( $p == 0 ) {
+        return GetScalar(1);
+    }
+    elsif ( $p == 1 ) {
+        return $n;
+    }
+    else {
+        $p--;
+        $n = $n->times($self) while $p--;
+        return $n;
+    }
+
+}
+
+sub _overload_sin {
+    my $self = shift;
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_sin'
+        if !ref $self;
+
+    carp "Warning: Arguments to sin() would be without dimension, traditionally. (got '$self')"
+        unless ref($self) eq 'Physics::Unit::Dimensionless';
+
+    return sin($self->{value});
+}
+
+sub _overload_cos {
+    my $self = shift;
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_cos'
+        if !ref $self;
+
+    carp "Warning: Arguments to cos() would be without dimension, traditionally. (got '$self')"
+        unless ref($self) eq 'Physics::Unit::Dimensionless';
+
+    return cos($self->{value});
+}
+
+# by overloading <=>, we will get the other comparison operators too
+sub _overload_spaceship {
+    my $self = shift;   
+    my $other = GetScalar(shift);
+    my $swapped = shift;
+
+    croak 'Invalid arguments to Physics::Unit::Scalar::_overload_spaceship'
+        if !ref $self || !ref $other;
+    
+    if (    (ref($self) eq ref($other)) || 
+            (ref($self) eq 'Physics::Unit::Dimensionless') || 
+            (ref($other) eq 'Physics::Unit::Dimensionless') ) {
+
+        return $swapped ? $other->{value} <=> $self->{value} : $self->{value} <=> $other->{value};
+    }
+    else {
+        # perhaps being a bit strict here
+        croak 'Cannot compare a ' . ref($self) . ' to a ' . ref($other);
+    }
+}
+
+use overload
+    "+"         =>      \&_overload_add,
+    "-"         =>      \&_overload_subtract,
+    "*"         =>      \&_overload_times,
+    "/"         =>      \&_overload_divide,
+    "**"        =>      \&_overload_power,
+    "sin"       =>      \&_overload_sin,
+    "cos"       =>      \&_overload_cos,
+    "<=>"       =>      \&_overload_spaceship,
+    "eq"        =>      \&_overload_eq,
+    '""'        =>      \&_overload_ToString,
+    "0+"        =>      sub { $_[0]->value() },
+    "bool"      =>      sub { $_[0]->value() },
+    ;
+
 1;
 
 __END__
@@ -322,13 +607,13 @@ Physics::Unit::Scalar
     print $t->ToString, "\n";              # prints 129600 second
 
     # Speed = Distance / Time
-    $s = $d->div($t);            # $s is a Physics::Unit::Speed object
+    $s = $d->divide($t);            # $s is a Physics::Unit::Speed object
     print $s->ToString, "\n";    # prints 1.2941... mps
 
     # Automatic typing
     $s = new Physics::Unit::Scalar('kg m s');   # Unrecognized type
     print ref $s, "\n";          # $s is a Physics::Unit::Scalar
-    $f = $s->div('3000 s^3');
+    $f = $s->divide('3000 s^3');
     print ref $f, "\n";          # $f is a Physics::Unit::Force
 
 =head1 DESCRIPTION
@@ -363,7 +648,7 @@ correct type automatically.  For example:
   $d = new Physics::Unit::Distance('98 mi');
   $t = new Physics::Unit::Time('36 years');
   # $s will be of type Physics::Unit::Speed.
-  $s = $d->div($t);
+  $s = $d->divide($t);
 
 When a new object is created, this package attempts to determine its
 subclass based on its dimensionality.  Thus, when you multiply two
@@ -490,6 +775,46 @@ This returns a new Scalar object which is a quotient.
 Neither the original object nor the argument is changed.
 
 =back
+
+=head1 OVERLOADED OPERATORS
+
+These operators are overloaded: +, -, *, /, **, sin, cos, <=>, eq, "", 0+ and bool.
+
+As mentioned above, it is possible to units to be indeterminate from their
+dimensions alone, for example, energy and torque have the same dimensions. For 
+cases where this ambiguity might arise during use of the overloaded interface, 
+a package variable C<@type_context> has been provided so the user can specify. 
+It's not a requirement, but it's possible an inappropriate unit might appear
+if this variable is not set up.
+
+To facilitate output when producing a string representation, the C<$format_string>
+package variable can be given a sprintf-compatible format string to e.g. restrict 
+the number of decimal places.
+
+The following example illustrates usage of the overloaded interface and the 
+variables described above.
+
+    # simple projectile motion simulation on different planets
+    use Physics::Unit::Scalar ':ALL';
+    @Physics::Unit::Scalar::type_context = ('Energy');      # we are working with energy i.e. Joules
+    $Physics::Unit::Scalar::format_string = "%.3f";         # provide a format string for output
+    my $m = GetScalar("1 Kg");                              # mass
+    my $u = GetScalar("1 meter per second");                # initial upward velocity
+    foreach my $body ( qw(mercury earth mars jupiter pluto) ) {
+        my $a = GetScalar("-1 $body-gravity");              # e.g. "-1 earth-gravity" (-1 for direction vector)
+        my $t = GetScalar("0 seconds");                     # start at t = 0s
+        print "On " . ucfirst($body) . ":\n";               # so we know which planet we're on
+        while ( $t < 3.5 ) {                                # simulate for a few seconds
+            my $s = $u * $t + (1/2) * $a * $t**2;           # 'suvat' equations
+            my $v = $u + $a * $t;
+            my $KE = (1/2) * $m * $v**2;                    # kinetic energy
+            my $PE = $m * -1 * $a * $s;                     # potential energy, again -1 for direction
+            my $TE = $KE + $PE;                             # total energy (should be constant)
+            # display with units
+            print "At $t: dist = $s;\tvel = $v;\tKE = $KE;\tPE = $PE;\tTotal energy = $TE\n";
+            $t += 0.1;                                      # increment timestep
+        }
+    }
 
 =head1 AUTHOR
 

--- a/t/overload.t
+++ b/t/overload.t
@@ -1,0 +1,55 @@
+use strict;
+use Physics::Unit::Scalar qw(GetScalar);
+use Test::More tests => 27;
+
+my $d1 = new Physics::Unit::Distance('10 meters');
+ok(defined $d1, "new Physics::Unit::Distance('10 meters')");
+is(ref($d1), 'Physics::Unit::Distance', '$d1 is distance type');
+
+my $d2 = new Physics::Unit::Distance('2 meters');
+ok(defined $d2, "new Physics::Unit::Distance('2 meters')");
+is(ref($d2), 'Physics::Unit::Distance', '$d2 is distance type');
+
+my $d3 = new Physics::Unit::Distance('5 meters');
+ok(defined $d3, "new Physics::Unit::Distance('5 meters')");
+is(ref($d3), 'Physics::Unit::Distance', '$d3 is distance type');
+
+my $d12p = $d1 + $d2;
+ok(defined $d12p, "defined \$d12p = \$d1 + \$d2 (overloaded '+')");
+is($d12p, '12 meter', "\$d12p eq '12 meter' (overloaded 'eq')");
+ok($d12p > $d3, "\$d12p > \$d3 (overloaded <=>)");
+
+$d12p++;
+ok(defined $d12p, "defined \$d12p++ (overloaded '+')");
+ok($d12p == 13, "\$d12p == 13 (overloaded <=>)");
+
+my $d31m = $d3 - $d1;
+ok(defined $d31m, "defined \$d31m = \$d3 - \$d1 (overloaded '-')");
+is($d31m, '-5 meter', "\$d31m eq '-5 meter' (overloaded 'eq')");
+ok($d31m == -5, "\$d31m == -5 (overloaded <=>)");
+
+my $d32m = 3 - $d2;
+ok(defined $d32m, "defined \$d32m = 3 - \$d2 (overloaded '-')");
+is($d32m, '1 meter', "\$d32m eq '1 meter' (overloaded 'eq')");
+ok($d32m == 1, "\$d32m == 1 (overloaded <=>)");
+
+my @sorted = sort { $a <=> $b } ($d1, $d2, $d3, $d12p, $d31m, $d32m);
+ok($sorted[0] eq '-5 meter', "sorting with <=>; first entry is '-5 meter'");
+ok($sorted[-1] eq '13 meter', "sorting with <=>; last entry is '13 meter'");
+
+my $d32mc = $d32m**3;
+ok(defined $d32mc, "defined \$d32m**3 (overloaded **)");
+is($d32mc, '1000 liter', "\$d32mc eq '1000 liter' (overloaded 'eq')");
+
+$d32mc /= $d2**2;
+ok(defined $d32mc, "defined \$d32m /= \$d2**2 (overloaded / and **)");
+is($d32mc, '0.25 meter', "\$d32mc eq '0.25 meter' (overloaded 'eq')");
+
+my $angle1 = GetScalar("90 degrees");
+ok(defined $angle1, "defined \$angle1 = 90 degrees");
+is(ref($angle1), 'Physics::Unit::Dimensionless', '$angle1 is without dimension');
+my $sin_test = sprintf("%.1f", sin($angle1));
+is($sin_test, "1.0", "sin(\$angle1) = 1 (overloaded 'sin')");
+my $cos_test = sprintf("%.1f", cos($angle1));
+is($cos_test, "0.0", "cos(\$angle1) = 0 (overloaded 'cos')");
+

--- a/t/unit.t
+++ b/t/unit.t
@@ -144,7 +144,9 @@ is($u->expanded, '8 m s^-1', '8 m s^-1');
 # define your own units
 $Uforce = new Physics::Unit('3 pi kg*nanoparsecs / femtofortnight sec');
 ok(!defined $Uforce->name, '$Uforce->name');
-like($Uforce->expanded, qr/2\.40216521602612\d*e\+0*20 m gm s\^-2/, '$Uforce->expanded');
+#like($Uforce->expanded, qr/2\.40216521602612\d*e\+0*20 m gm s\^-2/, '$Uforce->expanded');
+# Fix this test for quadmath systems: they can represent the entire number without exponential notation
+ok( ($Uforce->expanded =~ m/2\.40216521602612\d*e\+0*20 m gm s\^-2/) || ($Uforce->expanded eq '240216521602612414541.059027777778 m gm s^-2'), '$Uforce->expanded');
 
 $Uaccl1 = new Physics::Unit('meters per second squared');
 ok(!defined $Uaccl1->name, '$Uforce->name');


### PR DESCRIPTION
… in Unit.pm

Hi! I hope you consider my pull request. I have made the following changes:-
1. The examples and POD for Scalar.pm incorrectly referred to "div()" instead of "divide()", causing the examples to crash (updated).
2. A test in unit.t appears to be failing on quad-precision systems because they have the fortune of being able to represent a number without resorting to e notation (patched).
3. I have added some overloading to operators in Scalar.pm, as that made things easier for what I was working on. I have added an example and a test file for this.
4. I have added some new units in Unit.pm, relating to different planets. 
Thanks.
